### PR TITLE
Update FindMeetingQuery.java to pass all tests

### DIFF
--- a/walkthroughs/week-4-tdd/intro/src/main/java/com/google/sps/Greeter.java
+++ b/walkthroughs/week-4-tdd/intro/src/main/java/com/google/sps/Greeter.java
@@ -22,6 +22,6 @@ public class Greeter {
    * Returns a greeting for the given name.
    */
   public String greet(String name) {
-    return "Hello " + name;
+    return "Hello " + name.trim();
   }
 }

--- a/walkthroughs/week-4-tdd/intro/src/test/java/com/google/sps/GreeterTest.java
+++ b/walkthroughs/week-4-tdd/intro/src/test/java/com/google/sps/GreeterTest.java
@@ -30,4 +30,14 @@ public final class GreeterTest {
 
     Assert.assertEquals("Hello Ada", greeting);
   }
+
+  @Test
+  public void testGreetingTrimsWhitespace() {
+    Greeter greeter = new Greeter();
+
+    String greeting = greeter.greet("   Ada   ");
+
+    // Whitespace should be trimmed
+    Assert.assertEquals("Hello Ada", greeting);
+  }
 }

--- a/walkthroughs/week-4-tdd/project/src/main/java/com/google/sps/Event.java
+++ b/walkthroughs/week-4-tdd/project/src/main/java/com/google/sps/Event.java
@@ -19,11 +19,13 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import java.util.Comparator;
+
 /**
  * Event is the container class for when a specific group of people are meeting and are therefore
  * busy. Events are considered read-only.
  */
-public final class Event {
+public final class Event{
   private final String title;
   private final TimeRange when;
   private final Set<String> attendees = new HashSet<>();

--- a/walkthroughs/week-4-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-4-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -15,9 +15,89 @@
 package com.google.sps;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Arrays;
+import java.util.ArrayList;
+
+import java.util.Comparator;
+import java.util.Iterator;
 
 public final class FindMeetingQuery {
+  /*
+  * For a particular time slot to work, all attendees must be free to attend the meeting. When a query is made, it will be given a collection of all known events. 
+  * SOLUTION : Check to see if any attendees from the meeting request are already in events for a specfied time, if they are then the timeslot is not avaiable else it is.
+  * Return 
+  */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+    /*
+    // sort by start time inplace
+    EventComparator eventComparator = new EventComparator();
+    Collections.sort(events, eventComparator);
+    System.out.print(events);
+    */
+    //System.out.print("EVENTS ARE: " + events);
+
+    //base case : No events, and duration of request is greater than a whole day
+    if( (request.getDuration() > TimeRange.WHOLE_DAY.duration()) && events.isEmpty()) {
+        return Arrays.asList();
+    }
+    // base case: No events
+    if(events.isEmpty()){
+        return Arrays.asList(TimeRange.WHOLE_DAY);
+    }
+    
+    int start_time = TimeRange.START_OF_DAY;
+    int end_time = 0;
+    Event prevEvent = null;
+
+    boolean canAllAttendeesAttend = true;
+    boolean isInclusive = false;
+
+    Collection<TimeRange> result = new ArrayList<TimeRange>();
+
+    Iterator<Event> iterator = events.iterator();
+    while (iterator.hasNext()) {
+        Event event = iterator.next();
+        
+        // check to see if there are any attendees that can not particpate
+        for(String attendee: request.getAttendees()) {          
+            if(event.getAttendees().contains(attendee)) {
+                canAllAttendeesAttend = false;
+            }
+        }
+
+        if( (event.getWhen().start() == TimeRange.START_OF_DAY) && !canAllAttendeesAttend) {
+            start_time = event.getWhen().end();
+        }
+        // overlapping case: more stricter
+        else if( (prevEvent != null) &&  prevEvent.getWhen().overlaps(event.getWhen()) && !canAllAttendeesAttend) {
+            // case below handles nested events
+            if( prevEvent.getWhen().end() > event.getWhen().end()) {
+                start_time = prevEvent.getWhen().end();
+            }
+            else {
+                start_time = event.getWhen().end();
+            }
+
+        }
+        else if(!canAllAttendeesAttend && ( (start_time + request.getDuration()) <= event.getWhen().start() ) ){
+            end_time = event.getWhen().start();
+            result.add(TimeRange.fromStartEnd(start_time, end_time, isInclusive));
+            start_time = event.getWhen().end();
+        }
+        else {
+            end_time = event.getWhen().end();
+        }
+
+        // last event
+        if(!iterator.hasNext() && !(event.getWhen().end() == (TimeRange.END_OF_DAY+1)) ){
+            isInclusive = true;
+            end_time = TimeRange.END_OF_DAY;
+            result.add(TimeRange.fromStartEnd(start_time, end_time, isInclusive));
+        }
+        prevEvent = event;
+    }
+
+    return result;
   }
 }


### PR DESCRIPTION
Unable to use comparator to sort the events by start time due to technical difficulties, but will try to fix it (include it) in an upcoming pull request.